### PR TITLE
Fix compiler warning in HealthKitManager

### DIFF
--- a/YOGURT/HealthKitManager.swift
+++ b/YOGURT/HealthKitManager.swift
@@ -61,7 +61,7 @@ final class HealthKitManager {
             HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!
         ]
 
-        var write: Set<HKSampleType> = []
+        let write: Set<HKSampleType> = []
 
         if #available(iOS 14.0, *) {
             if let standType = HKQuantityType.quantityType(


### PR DESCRIPTION
## Summary
- make the write authorization set immutable

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project YoGurt.xcodeproj -scheme YoGurt -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683feb6155ac832fabb7d51142bb890f