### PR TITLE
Start observing workouts on launch

### DIFF
--- a/YOGURT/HealthWebhookApp.swift
+++ b/YOGURT/HealthWebhookApp.swift
@@ -38,6 +38,9 @@ struct HealthWebhookApp: App {
                 UploadService.shared.scheduleHourly()
 
                 NotificationManager.shared.setupHourlyReminders()
+
+                // Start monitoring workout sessions
+                HealthKitManager.shared.startObservingWorkouts()
             }
 
             return true


### PR DESCRIPTION
## Summary
- begin workout observation after HealthKit authorization so workout events are captured in realtime

## Testing
- `xcodebuild test -project YoGurt.xcodeproj -scheme YOGURT -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404e9cde1c832f847823914930ac1c