### PR TITLE
Add HealthKit usage descriptions

### DIFF
--- a/YOGURT/Info.plist
+++ b/YOGURT/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>NSUserNotificationUsageDescription</key>
 	<string>Мы используем уведомления, чтобы напоминать о синхронизации данных.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Нам нужен доступ на чтение данных HealthKit, чтобы анализировать вашу активность и сон.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Мы записываем настроение в HealthKit для ведения истории в Здоровье.</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.yourcompany.HealthWebhookApp.hourlyUpload</string>


### PR DESCRIPTION
## Summary
- add missing NSHealthShareUsageDescription and NSHealthUpdateUsageDescription entries in `Info.plist`

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404e9e49d0832f815530b20293f72e