### PR TITLE
Use helper JSON encoder

### DIFF
--- a/YOGURT/WebhookClient.swift
+++ b/YOGURT/WebhookClient.swift
@@ -15,16 +15,13 @@ final class WebhookClient {
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        do {
-            let jsonData = try JSONEncoder().encode(payload)
-            req.httpBody = jsonData
-
-            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                print("📦 Sending payload JSON:\n\(jsonString)")
-            }
-        } catch {
-            print("❌ Failed to encode payload: \(error)")
-            completion?(.failure(error))
+        if let jsonString = encodeToJSON(payload) {
+            req.httpBody = jsonString.data(using: .utf8)
+            print("📦 Sending payload JSON:\n\(jsonString)")
+        } else {
+            let err = NSError(domain: "WebhookClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to encode payload"])
+            print("❌ Failed to encode payload")
+            completion?(.failure(err))
             return
         }
 


### PR DESCRIPTION
## Summary
- clean up WebhookClient payload sending by using the helper `encodeToJSON`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68404e9fe6c0832fb8eeeedf520bed26