### PR TITLE
Add HealthKit observers for realtime uploads

### DIFF
--- a/YOGURT/HealthKitManager.swift
+++ b/YOGURT/HealthKitManager.swift
@@ -453,6 +453,61 @@ final class HealthKitManager {
 
         store.execute(query)
     }
+
+    // MARK: — Observer Queries
+
+    func startObservers() {
+        let quantityIds: [HKQuantityTypeIdentifier] = [
+            .stepCount,
+            .distanceWalkingRunning,
+            .activeEnergyBurned,
+            .appleExerciseTime,
+            .heartRate,
+            .restingHeartRate,
+            .heartRateVariabilitySDNN
+        ]
+
+        for id in quantityIds {
+            if let type = HKObjectType.quantityType(forIdentifier: id) {
+                let observer = HKObserverQuery(sampleType: type, predicate: nil) { [weak self] _, completion, error in
+                    guard error == nil else { completion(); return }
+                    self?.collectHourlyMetrics { metrics in
+                        UploadService.shared.uploadHourlyMetrics(metrics)
+                        completion()
+                    }
+                }
+                store.execute(observer)
+                store.enableBackgroundDelivery(for: type, frequency: .immediate) { _,_ in }
+            }
+        }
+
+        let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!
+        let sleepObserver = HKObserverQuery(sampleType: sleepType, predicate: nil) { [weak self] _, completion, error in
+            guard error == nil else { completion(); return }
+            self?.collectCombinedSleepAnalysis { analysis in
+                if let analysis = analysis { UploadService.shared.uploadSleepAnalysis(analysis) }
+                completion()
+            }
+        }
+        store.execute(sleepObserver)
+        store.enableBackgroundDelivery(for: sleepType, frequency: .immediate) { _,_ in }
+
+        if #available(iOS 15.0, *) {
+            if let mindful = HKObjectType.categoryType(forIdentifier: .mindfulSession) {
+                let obs = HKObserverQuery(sampleType: mindful, predicate: nil) { [weak self] _, completion, error in
+                    guard error == nil else { completion(); return }
+                    self?.collectHourlyMetrics { metrics in
+                        UploadService.shared.uploadHourlyMetrics(metrics)
+                        completion()
+                    }
+                }
+                store.execute(obs)
+                store.enableBackgroundDelivery(for: mindful, frequency: .immediate) { _,_ in }
+            }
+        }
+
+        startObservingWorkouts()
+    }
     
     
     // MARK: — Реaltime workout
@@ -464,7 +519,7 @@ final class HealthKitManager {
         ) { [weak self] _, completion, error in
             guard error == nil else { completion(); return }
             self?.fetchRecentWorkouts { sessions in
-                    //sessions.forEach { UploadService.shared.handleWorkoutEvent($0) }
+                sessions.forEach { UploadService.shared.handleWorkoutEvent($0) }
                 completion()
             }
         }

--- a/YOGURT/HealthWebhookApp.swift
+++ b/YOGURT/HealthWebhookApp.swift
@@ -37,6 +37,8 @@ struct HealthWebhookApp: App {
                 print("✅ HealthKit auth granted")
                 UploadService.shared.scheduleHourly()
 
+                HealthKitManager.shared.startObservers()
+
                 NotificationManager.shared.setupHourlyReminders()
             }
 

--- a/YOGURT/UploadService.swift
+++ b/YOGURT/UploadService.swift
@@ -91,6 +91,22 @@ final class UploadService {
         }
     }
 
+    // Отправка обновленных метрик по наблюдателям
+    func uploadHourlyMetrics(_ metrics: [HourlyMetric]) {
+        let payload = buildPayload(metrics: metrics)
+        client.send(payload: payload) { result in
+            print("📤 Metrics update sent:", result)
+        }
+    }
+
+    // Отправка новой информации о сне
+    func uploadSleepAnalysis(_ analysis: SleepAnalysis) {
+        let payload = buildPayload(sleepAnalysis: analysis)
+        client.send(payload: payload) { result in
+            print("📤 Sleep analysis sent:", result)
+        }
+    }
+
     // MARK: — Payload constructor
     private func buildPayload(
         metrics: [HourlyMetric]? = nil,


### PR DESCRIPTION
## Summary
- observe key HealthKit types for updates
- upload metrics and sleep data when observers fire
- relay workout sessions to the server immediately
- start observers when HealthKit authorization succeeds

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68404e9b9254832fb211474ca46ef1bd