### PR TITLE
Implement HealthKit background observers

### DIFF
--- a/YOGURT/HealthKitManager.swift
+++ b/YOGURT/HealthKitManager.swift
@@ -455,6 +455,41 @@ final class HealthKitManager {
     }
     
     
+    func startObservers() {
+        var typesToObserve: [HKSampleType] = [
+            HKObjectType.quantityType(forIdentifier: .stepCount)!,
+            HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
+            HKObjectType.quantityType(forIdentifier: .appleExerciseTime)!,
+            HKObjectType.quantityType(forIdentifier: .heartRate)!,
+            HKObjectType.quantityType(forIdentifier: .oxygenSaturation)!,
+            HKObjectType.quantityType(forIdentifier: .bodyMass)!,
+            HKObjectType.quantityType(forIdentifier: .bodyMassIndex)!,
+            HKObjectType.quantityType(forIdentifier: .restingHeartRate)!,
+            HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
+            HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!,
+            HKObjectType.workoutType()
+        ]
+        if let mindful = HKObjectType.categoryType(forIdentifier: .mindfulSession) {
+            typesToObserve.append(mindful)
+        }
+        typesToObserve += HKSampleType.stateOfMindTypeIfAvailable()
+
+        for type in typesToObserve {
+            let query = HKObserverQuery(sampleType: type, predicate: nil) { _, completion, _ in
+                print("\uD83D\uDD04 \u041E\u0431\u043D\u043E\u0432\u043B\u0435\u043D\u044B \u0434\u0430\u043D\u043D\u044B\u0435 \u043F\u043E \u0442\u0438\u043F\u0443: \(type.identifier)")
+                completion()
+            }
+            store.execute(query)
+            store.enableBackgroundDelivery(for: type, frequency: .immediate) { success, error in
+                if success {
+                    print("\u2705 \u0412\u043A\u043B\u044E\u0447\u0435\u043D\u043E \u0444\u043E\u043D. \u043E\u0442\u0441\u043B\u0435\u0436\u0438\u0432\u0430\u043D\u0438\u0435 \u0434\u043B\u044F: \(type.identifier)")
+                } else {
+                    print("\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0434\u043B\u044F \(type.identifier): \(error?.localizedDescription ?? \"unknown\")")
+                }
+            }
+        }
+    }
     // MARK: — Реaltime workout
 
     func startObservingWorkouts() {
@@ -715,5 +750,14 @@ private extension Double {
 private extension Date {
     var isoString: String {
         ISO8601DateFormatter().string(from: self)
+    }
+}
+
+extension HKSampleType {
+    static func stateOfMindTypeIfAvailable() -> [HKSampleType] {
+        if #available(iOS 18.0, *) {
+            return [HKSampleType.stateOfMindType()]
+        }
+        return []
     }
 }

--- a/YOGURT/HealthWebhookApp.swift
+++ b/YOGURT/HealthWebhookApp.swift
@@ -38,6 +38,8 @@ struct HealthWebhookApp: App {
                 UploadService.shared.scheduleHourly()
 
                 NotificationManager.shared.setupHourlyReminders()
+                HealthKitManager.shared.startObservers()
+                HealthKitManager.shared.startObservingWorkouts()
             }
 
             return true

--- a/YOGURT/Info.plist
+++ b/YOGURT/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>NSUserNotificationUsageDescription</key>
 	<string>Мы используем уведомления, чтобы напоминать о синхронизации данных.</string>
+        <key>NSHealthShareUsageDescription</key>
+        <string>Мы считываем ваши данные о здоровье для синхронизации.</string>
+        <key>NSHealthUpdateUsageDescription</key>
+        <string>Доступ требуется для записи новых показателей в HealthKit.</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.yourcompany.HealthWebhookApp.hourlyUpload</string>


### PR DESCRIPTION
## Summary
- add `startObservers()` to enable `HKObserverQuery` for all relevant health data types
- expose `stateOfMindTypeIfAvailable` helper
- register observers after HealthKit authorization and activate workout observation
- include HealthKit usage descriptions in `Info.plist`

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68404b45e0bc832fba6198543a74fc22