### PR TITLE
Fix duplicate startObservers and remove invalid unicode

### DIFF
--- a/YOGURT/HealthKitManager.swift
+++ b/YOGURT/HealthKitManager.swift
@@ -510,41 +510,6 @@ final class HealthKitManager {
     }
     
     
-    func startObservers() {
-        var typesToObserve: [HKSampleType] = [
-            HKObjectType.quantityType(forIdentifier: .stepCount)!,
-            HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
-            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
-            HKObjectType.quantityType(forIdentifier: .appleExerciseTime)!,
-            HKObjectType.quantityType(forIdentifier: .heartRate)!,
-            HKObjectType.quantityType(forIdentifier: .oxygenSaturation)!,
-            HKObjectType.quantityType(forIdentifier: .bodyMass)!,
-            HKObjectType.quantityType(forIdentifier: .bodyMassIndex)!,
-            HKObjectType.quantityType(forIdentifier: .restingHeartRate)!,
-            HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
-            HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!,
-            HKObjectType.workoutType()
-        ]
-        if let mindful = HKObjectType.categoryType(forIdentifier: .mindfulSession) {
-            typesToObserve.append(mindful)
-        }
-        typesToObserve += HKSampleType.stateOfMindTypeIfAvailable()
-
-        for type in typesToObserve {
-            let query = HKObserverQuery(sampleType: type, predicate: nil) { _, completion, _ in
-                print("\uD83D\uDD04 \u041E\u0431\u043D\u043E\u0432\u043B\u0435\u043D\u044B \u0434\u0430\u043D\u043D\u044B\u0435 \u043F\u043E \u0442\u0438\u043F\u0443: \(type.identifier)")
-                completion()
-            }
-            store.execute(query)
-            store.enableBackgroundDelivery(for: type, frequency: .immediate) { success, error in
-                if success {
-                    print("\u2705 \u0412\u043A\u043B\u044E\u0447\u0435\u043D\u043E \u0444\u043E\u043D. \u043E\u0442\u0441\u043B\u0435\u0436\u0438\u0432\u0430\u043D\u0438\u0435 \u0434\u043B\u044F: \(type.identifier)")
-                } else {
-                    print("\u274C \u041E\u0448\u0438\u0431\u043A\u0430 \u0434\u043B\u044F \(type.identifier): \(error?.localizedDescription ?? \"unknown\")")
-                }
-            }
-        }
-    }
     // MARK: — Реaltime workout
 
     func startObservingWorkouts() {


### PR DESCRIPTION
## Summary
- clean up `HealthKitManager` by removing a duplicate `startObservers` implementation
- the removed implementation contained invalid unicode escape sequences which caused the project to fail to compile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684056660b9c832fb7afaa882b058e50