### PR TITLE
Prevent duplicate metric uploads

### DIFF
--- a/YOGURT/ContentView.swift
+++ b/YOGURT/ContentView.swift
@@ -9,7 +9,9 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 20) {
             Button("Send Hourly Now") {
-                UploadService.shared.debugSendHourlyNow()
+                HealthKitManager.shared.collectHourlyMetrics { metrics in
+                    UploadService.shared.uploadHourlyMetricsOnce(metrics)
+                }
             }
         }
         .padding()
@@ -21,7 +23,14 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
                 print("🔔 Scene became active — forcing data sync")
-                UploadService.shared.debugSendHourlyNow()
+                HealthKitManager.shared.collectHourlyMetrics { metrics in
+                    UploadService.shared.uploadHourlyMetricsOnce(metrics)
+                }
+                HealthKitManager.shared.collectCombinedSleepAnalysis {
+                    if let sleep = $0 {
+                        UploadService.shared.uploadSleepAnalysis(sleep)
+                    }
+                }
             }
         }
     }

--- a/YOGURT/HealthKitManager.swift
+++ b/YOGURT/HealthKitManager.swift
@@ -472,7 +472,7 @@ final class HealthKitManager {
                 let observer = HKObserverQuery(sampleType: type, predicate: nil) { [weak self] _, completion, error in
                     guard error == nil else { completion(); return }
                     self?.collectHourlyMetrics { metrics in
-                        UploadService.shared.uploadHourlyMetrics(metrics)
+                        UploadService.shared.uploadHourlyMetricsOnce(metrics)
                         completion()
                     }
                 }
@@ -497,7 +497,7 @@ final class HealthKitManager {
                 let obs = HKObserverQuery(sampleType: mindful, predicate: nil) { [weak self] _, completion, error in
                     guard error == nil else { completion(); return }
                     self?.collectHourlyMetrics { metrics in
-                        UploadService.shared.uploadHourlyMetrics(metrics)
+                        UploadService.shared.uploadHourlyMetricsOnce(metrics)
                         completion()
                     }
                 }

--- a/YOGURT/HealthWebhookApp.swift
+++ b/YOGURT/HealthWebhookApp.swift
@@ -54,9 +54,7 @@ struct HealthWebhookApp: App {
                 UploadService.shared.scheduleDailyEvening()
 
                 HealthKitManager.shared.startObservers()
-
                 NotificationManager.shared.setupHourlyReminders()
-                HealthKitManager.shared.startObservers()
                 HealthKitManager.shared.startObservingWorkouts()
             }
 
@@ -65,7 +63,14 @@ struct HealthWebhookApp: App {
 
         func applicationDidBecomeActive(_ application: UIApplication) {
             print("🔔 App became active — forcing data sync")
-            UploadService.shared.debugSendHourlyNow()
+            HealthKitManager.shared.collectHourlyMetrics { metrics in
+                UploadService.shared.uploadHourlyMetricsOnce(metrics)
+            }
+            HealthKitManager.shared.collectCombinedSleepAnalysis {
+                if let sleep = $0 {
+                    UploadService.shared.uploadSleepAnalysis(sleep)
+                }
+            }
         }
     }
     

--- a/YOGURT/UploadService.swift
+++ b/YOGURT/UploadService.swift
@@ -8,6 +8,9 @@ final class UploadService {
         webhookURL: URL(string: "https://wordpressdev.karpovpartners-it.ru/health/index.php")!
     )
 
+    // Запоминаем последнюю успешную отправку, чтобы избегать дубликатов
+    private var lastSentTimestamp: String?
+
     private init() {}
 
     // MARK: — Планирование фоновых задач
@@ -165,6 +168,17 @@ final class UploadService {
         client.send(payload: payload) { result in
             print("📤 Metrics update sent:", result)
         }
+    }
+
+    /// Безопасная отправка метрик, предотвращающая дубли
+    func uploadHourlyMetricsOnce(_ metrics: [HourlyMetric]) {
+        guard let stamp = metrics.first?.interval.end else { return }
+        if stamp == lastSentTimestamp {
+            print("⛔️ Duplicate metrics. Skipping upload.")
+            return
+        }
+        lastSentTimestamp = stamp
+        uploadHourlyMetrics(metrics)
     }
 
     // Отправка новой информации о сне


### PR DESCRIPTION
## Summary
- add `lastSentTimestamp` tracking in `UploadService`
- implement `uploadHourlyMetricsOnce` to skip duplicate payloads
- switch observers to use the new method
- trigger hourly metric and sleep uploads once when the app becomes active
- update manual send button logic

## Testing
- `xcodebuild -list -project YoGurt.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684059cf2ec0832fa9a8105f7f4e91c0