### PR TITLE
Implement background data collection with HKAnchoredObjectQuery

### DIFF
--- a/YOGURT/ContentView.swift
+++ b/YOGURT/ContentView.swift
@@ -9,10 +9,7 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 20) {
             Button("Send Hourly Now") {
-                HealthDataFetcher.shared.fetchAllHealthData { payload in
-                    UploadService.shared.uploadIfNeeded(metrics: payload.metrics)
-                    UploadService.shared.uploadIfNeeded(sleep: payload.sleep)
-                }
+                UploadService.shared.debugSendHourlyNow()
             }
         }
         .padding()
@@ -24,10 +21,7 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
                 print("🔔 Scene became active — forcing data sync")
-                HealthDataFetcher.shared.fetchAllHealthData { payload in
-                    UploadService.shared.uploadIfNeeded(metrics: payload.metrics)
-                    UploadService.shared.uploadIfNeeded(sleep: payload.sleep)
-                }
+                UploadService.shared.debugSendHourlyNow()
             }
         }
     }

--- a/YOGURT/HealthWebhookApp.swift
+++ b/YOGURT/HealthWebhookApp.swift
@@ -63,10 +63,7 @@ struct HealthWebhookApp: App {
 
         func applicationDidBecomeActive(_ application: UIApplication) {
             print("🔔 App became active — forcing data sync")
-            HealthDataFetcher.shared.fetchAllHealthData { payload in
-                UploadService.shared.uploadIfNeeded(metrics: payload.metrics)
-                UploadService.shared.uploadIfNeeded(sleep: payload.sleep)
-            }
+            UploadService.shared.debugSendHourlyNow()
         }
     }
     

--- a/YOGURT/UploadService.swift
+++ b/YOGURT/UploadService.swift
@@ -81,33 +81,32 @@ final class UploadService {
 
     // MARK: — Сбор payload
     private func collectHourlyPayload(completion: @escaping (HealthPayload) -> Void) {
-        HealthKitManager.shared.collectHourlyMetrics { metrics in
-            let now = Date()
-            if #available(iOS 18.0, *) {
-                let start = Calendar.current.startOfDay(for: now)
-                HealthKitManager.shared.collectFullMoodData(from: start, to: now) { moods in
-                    HealthKitManager.shared.collectCombinedSleepAnalysis { sleep in
-                        HealthKitManager.shared.collectSleepEvents { sleepEvents in
-                            let moodSessions = moods.map { $0.toMoodSession() }
-                            completion(self.buildPayload(
-                                metrics: metrics,
-                                sleepAnalysis: sleep,
-                                moodSessions: moodSessions,
-                                healthEvents: sleepEvents    // ← добавлено
-                            ))
-                        }
-                    }
-                }
-            } else {
+        let metrics = HealthKitManager.shared.cachedHourlyMetrics()
+        let now = Date()
+        if #available(iOS 18.0, *) {
+            let start = Calendar.current.startOfDay(for: now)
+            HealthKitManager.shared.collectFullMoodData(from: start, to: now) { moods in
                 HealthKitManager.shared.collectCombinedSleepAnalysis { sleep in
                     HealthKitManager.shared.collectSleepEvents { sleepEvents in
+                        let moodSessions = moods.map { $0.toMoodSession() }
                         completion(self.buildPayload(
                             metrics: metrics,
                             sleepAnalysis: sleep,
-                            moodSessions: nil,
-                            healthEvents: sleepEvents     // ← добавлено
+                            moodSessions: moodSessions,
+                            healthEvents: sleepEvents    // ← добавлено
                         ))
                     }
+                }
+            }
+        } else {
+            HealthKitManager.shared.collectCombinedSleepAnalysis { sleep in
+                HealthKitManager.shared.collectSleepEvents { sleepEvents in
+                    completion(self.buildPayload(
+                        metrics: metrics,
+                        sleepAnalysis: sleep,
+                        moodSessions: nil,
+                        healthEvents: sleepEvents     // ← добавлено
+                    ))
                 }
             }
         }


### PR DESCRIPTION
## Summary
- keep latest HealthKit samples using HKObserverQuery and HKAnchoredObjectQuery
- cache metrics in memory and expose `cachedHourlyMetrics()`
- use cached metrics when assembling payloads
- simplify ContentView and AppDelegate to send using `UploadService` helpers

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68406e2498cc832f8c012b48884a92d4