### PR TITLE
Fix HealthKit quantity identifier cast

### DIFF
--- a/YOGURT/HealthKitManager.swift
+++ b/YOGURT/HealthKitManager.swift
@@ -140,7 +140,7 @@ final class HealthKitManager {
 
     private func processQuantitySamples(_ samples: [HKQuantitySample]) {
         for sample in samples {
-            guard let id = HKQuantityTypeIdentifier(rawValue: sample.quantityType.identifier) else { continue }
+            let id = HKQuantityTypeIdentifier(rawValue: sample.quantityType.identifier)
             let unit: HKUnit
             switch id {
             case .stepCount: unit = .count()


### PR DESCRIPTION
## Summary
- remove invalid optional binding for `HKQuantityTypeIdentifier`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6840705ba2a8832f9661907fcae4ed81