### PR TITLE
Add iOS AppIntent shortcut for data sync

### DIFF
--- a/YOGURT/HealthAppShortcuts.swift
+++ b/YOGURT/HealthAppShortcuts.swift
@@ -1,0 +1,12 @@
+import AppIntents
+
+struct HealthAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SendHealthDataIntent(),
+            phrases: ["Отправить данные с \(ApplicationShortcutsApplicationName)"],
+            shortTitle: "Синхронизация",
+            systemImageName: "arrow.up.circle.fill"
+        )
+    }
+}

--- a/YOGURT/Info.plist
+++ b/YOGURT/Info.plist
@@ -14,6 +14,10 @@
 		<string>com.yourcompany.HealthWebhookApp.dailyMorningUpload</string>
 		<string>com.yourcompany.HealthWebhookApp.dailyEveningUpload</string>
 	</array>
+        <key>IntentsSupported</key>
+        <array>
+                <string>SendHealthDataIntent</string>
+        </array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/YOGURT/SendHealthDataIntent.swift
+++ b/YOGURT/SendHealthDataIntent.swift
@@ -1,0 +1,12 @@
+import AppIntents
+
+struct SendHealthDataIntent: AppIntent {
+    static var title: LocalizedStringResource = "Отправить данные на сервер"
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            UploadService.shared.debugSendHourlyNow()
+        }
+        return .result()
+    }
+}


### PR DESCRIPTION
## Summary
- add SendHealthDataIntent and HealthAppShortcuts for iOS Shortcuts support
- register the intent in the app Info.plist

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840af484b68832f812b7f159b136b9e