### PR TITLE
Remove fallback app shortcut constant

### DIFF
--- a/YOGURT/HealthAppShortcuts.swift
+++ b/YOGURT/HealthAppShortcuts.swift
@@ -1,23 +1,4 @@
 import AppIntents
-import Foundation
-
-/// Apple's AppShortcuts framework normally exposes `ApplicationShortcutsApplicationName`
-/// for constructing phrases that contain the application's display name. The constant
-/// isn't available when building outside of Xcode, so we provide a fallback using the
-/// bundle information. This mirrors the behavior of the original constant and keeps the
-/// project building when the symbol isn't present.
-private let ApplicationShortcutsApplicationName: String = {
-    let info = Bundle.main
-    // Try the localized display name first, then the bundle name, and finally a
-    // sensible default.
-    if let displayName = info.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
-        return displayName
-    }
-    if let bundleName = info.object(forInfoDictionaryKey: "CFBundleName") as? String {
-        return bundleName
-    }
-    return "YOGURT"
-}()
 
 struct HealthAppShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {


### PR DESCRIPTION
## Summary
- remove the custom `ApplicationShortcutsApplicationName` fallback

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840b12e7a78832f8284d556782fbb30