### PR TITLE
Fix missing constant in AppShortcuts

### DIFF
--- a/YOGURT/HealthAppShortcuts.swift
+++ b/YOGURT/HealthAppShortcuts.swift
@@ -1,5 +1,10 @@
 import AppIntents
 
+/// The display name used for the app's system shortcuts.
+/// This constant is not provided automatically by Xcode, so we define it here
+/// to ensure that the shortcut phrases compile correctly.
+private let ApplicationShortcutsApplicationName = "Yogurt"
+
 struct HealthAppShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(


### PR DESCRIPTION
## Summary
- define `ApplicationShortcutsApplicationName` constant
- use it when creating the custom intent phrase

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840b51a99cc832fbe086bfd5d6234e0