### PR TITLE
Fix AppShortcuts init and add screen time intents

### DIFF
--- a/YOGURT/HealthAppShortcuts.swift
+++ b/YOGURT/HealthAppShortcuts.swift
@@ -2,13 +2,15 @@ import AppIntents
 
 struct HealthAppShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
-        AppShortcut(
-            intent: SendHealthDataIntent(),
-            phrases: [
-                AppShortcutPhrase("Отправить данные с ${applicationName}")
-            ],
-            shortTitle: "Синхронизация",
-            systemImageName: "arrow.up.circle.fill"
-        )
+        [
+            AppShortcut(
+                intent: SendHealthDataIntent(),
+                phrases: [
+                    AppShortcutPhrase("Отправить данные с ${applicationName}")
+                ],
+                shortTitle: "Синхронизация",
+                systemImageName: "arrow.up.circle.fill"
+            )
+        ]
     }
 }

--- a/YOGURT/ScreenTimeIntent.swift
+++ b/YOGURT/ScreenTimeIntent.swift
@@ -1,0 +1,29 @@
+import AppIntents
+
+struct StartAppSessionIntent: AppIntent {
+    static var title: LocalizedStringResource = "Начать сессию"
+
+    @Parameter(title: "Приложение")
+    var appName: String
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            SessionMemory.shared.start(app: appName)
+        }
+        return .result()
+    }
+}
+
+struct StopAppSessionIntent: AppIntent {
+    static var title: LocalizedStringResource = "Закончить сессию"
+
+    @Parameter(title: "Приложение")
+    var appName: String
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            SessionMemory.shared.stop(app: appName)
+        }
+        return .result()
+    }
+}


### PR DESCRIPTION
## Summary
- fix `HealthAppShortcuts.appShortcuts` return type
- add `StartAppSessionIntent` and `StopAppSessionIntent`

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c7da5c00832f9dce3027bee6c605