### PR TITLE
Fix AppShortcuts builder usage

### DIFF
--- a/YOGURT/HealthAppShortcuts.swift
+++ b/YOGURT/HealthAppShortcuts.swift
@@ -2,15 +2,13 @@ import AppIntents
 
 struct HealthAppShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
-        [
-            AppShortcut(
-                intent: SendHealthDataIntent(),
-                phrases: [
-                    AppShortcutPhrase("Отправить данные с ${applicationName}")
-                ],
-                shortTitle: "Синхронизация",
-                systemImageName: "arrow.up.circle.fill"
-            )
-        ]
+        AppShortcut(
+            intent: SendHealthDataIntent(),
+            phrases: [
+                AppShortcutPhrase("Отправить данные с ${applicationName}")
+            ],
+            shortTitle: "Синхронизация",
+            systemImageName: "arrow.up.circle.fill"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- ensure HealthAppShortcuts uses the result builder correctly

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9a59b78832fb2707bc9683d7f47