### PR TITLE
Remove dialog from SendHealthDataIntent

### DIFF
--- a/YOGURT/HealthKit/SendHealthDataIntent.swift
+++ b/YOGURT/HealthKit/SendHealthDataIntent.swift
@@ -7,6 +7,7 @@ struct SendHealthDataIntent: AppIntent {
         await MainActor.run {
             UploadService.shared.debugSendHourlyNow()
         }
-        return .result()
+        // Suppress the default completion announcement
+        return .result(dialog: IntentDialog(""))
     }
 }


### PR DESCRIPTION
## Summary
- return an empty dialog in `SendHealthDataIntent.perform()` so the system does not announce a success message

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684179cc3858832faad173fa337f2fb3