### PR TITLE
Implement screen time session intents

### DIFF
--- a/YOGURT/HealthAppShortcuts.swift
+++ b/YOGURT/HealthAppShortcuts.swift
@@ -1,0 +1,40 @@
+import AppIntents
+
+struct HealthAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        [
+            AppShortcut(
+                intent: SendHealthDataIntent(),
+                phrases: [
+                    AppShortcutPhrase("Отправить данные с ${applicationName}")
+                ],
+                shortTitle: "Синхронизация",
+                systemImageName: "arrow.up.circle.fill"
+            ),
+            AppShortcut(
+                intent: StartAppSessionIntent(),
+                phrases: [
+                    AppShortcutPhrase("Начать сессию в ${applicationName}")
+                ],
+                shortTitle: "Начать сессию",
+                systemImageName: "play.circle.fill"
+            ),
+            AppShortcut(
+                intent: StopAppSessionIntent(),
+                phrases: [
+                    AppShortcutPhrase("Закончить сессию в ${applicationName}")
+                ],
+                shortTitle: "Закончить сессию",
+                systemImageName: "stop.circle.fill"
+            ),
+            AppShortcut(
+                intent: UploadScreenTimeIntent(),
+                phrases: [
+                    AppShortcutPhrase("Отправить экранное время с ${applicationName}")
+                ],
+                shortTitle: "Экранное время",
+                systemImageName: "clock.arrow.circlepath"
+            )
+        ]
+    }
+}

--- a/YOGURT/StartAppSessionIntent.swift
+++ b/YOGURT/StartAppSessionIntent.swift
@@ -1,0 +1,29 @@
+import AppIntents
+
+struct StartAppSessionIntent: AppIntent {
+    static var title: LocalizedStringResource = "Начать сессию"
+
+    @Parameter(title: "Приложение")
+    var appName: String
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            SessionMemory.shared.start(app: appName)
+        }
+        return .result()
+    }
+}
+
+struct StopAppSessionIntent: AppIntent {
+    static var title: LocalizedStringResource = "Закончить сессию"
+
+    @Parameter(title: "Приложение")
+    var appName: String
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            SessionMemory.shared.stop(app: appName)
+        }
+        return .result()
+    }
+}

--- a/YOGURT/UploadScreenTimeIntent.swift
+++ b/YOGURT/UploadScreenTimeIntent.swift
@@ -1,0 +1,12 @@
+import AppIntents
+
+struct UploadScreenTimeIntent: AppIntent {
+    static var title: LocalizedStringResource = "Отправить экранное время"
+
+    func perform() async throws -> some IntentResult {
+        await MainActor.run {
+            ScreenTimeUploadService.shared.uploadTodayStats()
+        }
+        return .result()
+    }
+}


### PR DESCRIPTION
## Summary
- add screen time intents and include them in app shortcuts
- add UploadScreenTimeIntent for sending tracked screen time

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417b4ba8e4832fbbdb2a2714ae23f8